### PR TITLE
chore: migrate to ubuntu-slim runners for cost optimization

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -13,7 +13,7 @@ jobs:
           - testing-type: lint-git
           - testing-type: security-file-system
           - testing-type: yamllint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: schubergphilis/mcvs-general-action@v0.5.2

--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: read
 jobs:
   MCVS-PR-validation-action:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: schubergphilis/mcvs-pr-validation-action@v0.2.1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ permissions:
   pull-requests: write
 jobs:
   mcvs-golang-action-taskfile-remote-url-ref-updater:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       # yamllint disable rule:line-length
       - uses: schubergphilis/mcvs-golang-action-taskfile-remote-url-ref-updater@v0.1.0


### PR DESCRIPTION
## Description
This PR migrates GitHub Actions workflows from `ubuntu-24.04` to the new `ubuntu-slim` runner type, which is now available.

## Rationale
According to the [GitHub announcement](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/), `ubuntu-slim` runners are optimized for lightweight automation tasks and offer:

- **Cost-effective execution**: Lower cost compared to standard runners
- **Sufficient resources**: 1 vCPU and 5 GB RAM for our use case
- **Container-based execution**: Hypervisor level 2 isolation with automatic decommissioning

## Use Case Fit
Our workflows perform lightweight operations that are ideal for `ubuntu-slim` runners:
- Linting (commit messages, git, YAML)
- Security scanning (file system)
- Simple automation tasks

These tasks complete well within the 15-minute execution limit for `ubuntu-slim` runners.