### PR TITLE
refactor: fetch latest mcvs-golang-action version from GitHub API instead of golang.yml

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6.0.1
-      - uses: schubergphilis/mcvs-general-action@v0.5.3
+      - uses: schubergphilis/mcvs-general-action@v0.5.8
         with:
           testing-type: ${{ matrix.args.testing-type }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       # yamllint disable rule:line-length
-      - uses: schubergphilis/mcvs-golang-action-taskfile-remote-url-ref-updater@v0.1.0
+      - uses: schubergphilis/mcvs-golang-action-taskfile-remote-url-ref-updater@v0.2.0
       # yamllint enable rule:line-length
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This action will update the `REMOTE_URL_REF` that is defined
 [in the MCVS-golang-action Taskfile][mcvs-golang-action] automatically by
 creating a Pull Request if a newer version of the MCVS-golang action has been
-released. This will prevent that one will forget to update the Taskfile once
-Dependabot has been updated it.
+released. It fetches the latest release tag directly from the GitHub API,
+so there is no dependency on Dependabot updating workflow files first.
 
 [mcvs-golang-action]: https://github.com/schubergphilis/mcvs-golang-action
 

--- a/scripts/taskfile-remote-url-ref-updater.sh
+++ b/scripts/taskfile-remote-url-ref-updater.sh
@@ -121,8 +121,7 @@ main() {
   checkout_branch_required_to_apply_package_version_updates
 
   local version
-  version="$(extract_mcvs_golang_action_latest_version)"
-  if [ -z "${version}" ]; then
+  if ! version="$(extract_mcvs_golang_action_latest_version)" || [[ -z "${version}" ]]; then
     echo "Could not extract version from GitHub API!" >&2
     exit 1
   fi

--- a/scripts/taskfile-remote-url-ref-updater.sh
+++ b/scripts/taskfile-remote-url-ref-updater.sh
@@ -12,10 +12,8 @@ generate_pr_body_with_updates() {
   echo "PR_BODY: ${PR_BODY}"
 }
 
-extract_mcvs_golang_action_version_from_github_workflows_golang() {
-  grep -oE 'schubergphilis/mcvs-golang-action@[^ ]+' .github/workflows/golang.yml \
-    | head -n1 \
-    | sed -E 's/.*@//'
+extract_mcvs_golang_action_latest_version() {
+  gh api repos/schubergphilis/mcvs-golang-action/releases/latest --jq '.tag_name'
 }
 
 update_mcvs_golang_action_ref_in_taskfile() {
@@ -123,9 +121,9 @@ main() {
   checkout_branch_required_to_apply_package_version_updates
 
   local version
-  version="$(extract_mcvs_golang_action_version_from_github_workflows_golang)"
+  version="$(extract_mcvs_golang_action_latest_version)"
   if [ -z "${version}" ]; then
-    echo "Could not extract version from workflow!" >&2
+    echo "Could not extract version from GitHub API!" >&2
     exit 1
   fi
 


### PR DESCRIPTION
## Problem

The `extract_mcvs_golang_action_version_from_github_workflows_golang` function grepped the version from `.github/workflows/golang.yml`. This created a sequential dependency:

1. Dependabot detects a new `mcvs-golang-action` release and opens a PR to update `golang.yml`.
2. That PR must be reviewed and merged.
3. Only then can this updater script pick up the new version to update `Taskfile.yml`.

This two-step process introduced unnecessary delays between a release being published and the Taskfile being updated.

## Solution

Fetch the latest release tag directly from the GitHub API:

```bash
gh api repos/schubergphilis/mcvs-golang-action/releases/latest --jq '.tag_name'
```

This eliminates the dependency on workflow files being updated first — the updater now picks up new releases immediately.