### PR TITLE
fix: pin nested actions to a full-length commit SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ description: |
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - env:
         DEPENDENCIES_LABEL: dependencies
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

`action.yml` calls `actions/checkout` pinned to a version tag:

```yaml
- uses: actions/checkout@v6.0.2
```

GitHub resolves nested `uses:` **transitively when the consumer's job is set
up**, before any `if:` is evaluated. So in any repository whose ruleset enables
*"require actions to be pinned to a full-length commit SHA"*, this action cannot
be used at all. The job fails at setup in ~10s with no step logs
(`startup_failure`):

> The action `actions/checkout@v6.0.1` is not allowed in `schubergphilis/item`
> because all actions must be from a repository owned by schubergphilis, created
> by GitHub, or match one of the patterns: `actions/checkout@*`,
> `actions/setup-go@*`, `actions/setup-python@*`, … **All actions must also be
> pinned to a full-length commit SHA.**

Note the last sentence: adding `actions/checkout@*` to the allowlist patterns
does not help, because SHA pinning is an independent condition. The consumer's
own workflow is already fully SHA-pinned — only this nested reference breaks it.

Observed in [`schubergphilis/item`](https://github.com/schubergphilis/item),
where the scheduled `mcvs-golang-action-taskfile-remote-url-ref-updater`
workflow has been failing every day (e.g. run
[31156405256](https://github.com/schubergphilis/item/actions/runs/31156405256),
which hit `v6.0.1` from the v0.2.0 tag; `main` is now on `v6.0.2`).

## Change

Pin to the commit the tag already points at — no version change, no behaviour
change:

| Action | Tag | Commit |
|---|---|---|
| `actions/checkout` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |

The version stays in a trailing `# vX.Y.Z` comment, which is the form Dependabot
reads and updates — so the existing `.github/dependabot.yml` keeps bumping it.
At 78 characters the line stays under the yamllint limit enforced by
`general.yml`.

## Notes

- Consumers pin this action by tag/SHA, so a new release is needed before the
  fix reaches them.
- This repo's own workflows (`.github/workflows/general.yml`,
  `mcvs-pr-validation.yml`) also use tag-pinned actions. Left alone here to keep
  the change minimal — happy to include them if you'd prefer consistency.
